### PR TITLE
handleSuccess is wrapping results in array

### DIFF
--- a/lib/middlewares/responseBuilder.js
+++ b/lib/middlewares/responseBuilder.js
@@ -29,17 +29,8 @@ var json = (function(){
 
 		// use a variable like res.locals.results{}
 		// to store result data to be returned
-
-		// result data should be sent as an array
-		// if res.locals.results is not an array, then wrap it in an array
-		//if( res.locals.results && (res.locals.results.length > 0) ) {
-		if( Array.isArray(res.locals.results) ) {
-			response.data = res.locals.results;
-		} else {
-			response.data = [ res.locals.results ];
-		}
-		//}
-
+		response.data = res.locals.results;
+		
 		if( Object.getOwnPropertyNames(res.locals.customOutcome).length > 0 ) {
 		for( var prop in res.locals.customOutcome ) {
 				if( res.locals.customOutcome.hasOwnProperty(prop) ) {

--- a/lib/middlewares/routeHelper.js
+++ b/lib/middlewares/routeHelper.js
@@ -8,7 +8,7 @@ var routeHelper = (function() {
         if (data) {
             res.locals.status = 200;
             res.locals.message = domainName + ' found';
-            res.locals.results.push(data);
+            res.locals.results = data;
         } else {
             res.locals.status = 404;
             res.locals.message = domainName + ' not found';


### PR DESCRIPTION
I removed handleSuccess wrapping the data in an array.  It should just set the res.locals.results = data.  this was causing arrays to be pushed into another array when adding to locals.
